### PR TITLE
Fix touch index with Math.Abs

### DIFF
--- a/WaterEffect/OpenGLWaterEffectViewController.cs
+++ b/WaterEffect/OpenGLWaterEffectViewController.cs
@@ -151,7 +151,8 @@ public class OpenGLWaterEffectViewController : GLKViewController
             var location = touch.LocationInView(View);
             CGPoint normalizedLocation = NormalizeTouchLocation(location);
             Console.WriteLine($"Normalized Touch Began at: {normalizedLocation.X}, {normalizedLocation.Y}");
-            touchPoints[touch.GetHashCode() % MaxTouches] = normalizedLocation;
+            // GetHashCode can be negative, so use Math.Abs to keep the index within array bounds
+            touchPoints[Math.Abs(touch.GetHashCode()) % MaxTouches] = normalizedLocation;
         }
     }
 
@@ -169,7 +170,8 @@ public class OpenGLWaterEffectViewController : GLKViewController
 
         foreach (var touch in touches.Cast<UITouch>())
         {
-            touchPoints[touch.GetHashCode() % MaxTouches] = CGPoint.Empty;
+            // GetHashCode can be negative, so use Math.Abs to keep the index within array bounds
+            touchPoints[Math.Abs(touch.GetHashCode()) % MaxTouches] = CGPoint.Empty;
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure touch indices stay within array bounds by using `Math.Abs`
- clarify why `Math.Abs` is needed

## Testing
- `dotnet build WaterEffect.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68529a0e914083249e450201607ddcd9