### PR TITLE
Optimize ripple update

### DIFF
--- a/WaterEffect/EnhancedRippleViewController.cs
+++ b/WaterEffect/EnhancedRippleViewController.cs
@@ -209,9 +209,14 @@ public class EnhancedRippleViewController : UIViewController
     {
         int size = _rippleMap.GetLength(0);
 
-        for (int x = 1; x < size - 1; x++)
+        int startX = Math.Clamp(_affectedAreaStartX, 1, size - 1);
+        int endX = Math.Clamp(_affectedAreaEndX, 1, size - 1);
+        int startY = Math.Clamp(_affectedAreaStartY, 1, size - 1);
+        int endY = Math.Clamp(_affectedAreaEndY, 1, size - 1);
+
+        for (int x = startX; x < endX; x++)
         {
-            for (int y = 1; y < size - 1; y++)
+            for (int y = startY; y < endY; y++)
             {
                 float newHeight = (
                     _rippleMap[x - 1, y] +
@@ -222,6 +227,11 @@ public class EnhancedRippleViewController : UIViewController
                 _lastRippleMap[x, y] = newHeight * DampingFactor;
             }
         }
+
+        _affectedAreaStartX = startX;
+        _affectedAreaEndX = endX;
+        _affectedAreaStartY = startY;
+        _affectedAreaEndY = endY;
 
         SwapRippleMaps();
     }
@@ -237,6 +247,14 @@ public class EnhancedRippleViewController : UIViewController
     {
         _affectedAreaStartX = _affectedAreaStartY = 0;
         _affectedAreaEndX = _affectedAreaEndY = _mapSize;
+    }
+
+    private void ClampAffectedArea()
+    {
+        _affectedAreaStartX = Math.Clamp(_affectedAreaStartX, 0, _mapSize);
+        _affectedAreaEndX = Math.Clamp(_affectedAreaEndX, 0, _mapSize);
+        _affectedAreaStartY = Math.Clamp(_affectedAreaStartY, 0, _mapSize);
+        _affectedAreaEndY = Math.Clamp(_affectedAreaEndY, 0, _mapSize);
     }
 
     // Helper Methods
@@ -264,12 +282,13 @@ public class EnhancedRippleViewController : UIViewController
     #region Timer and Rendering
     private void TimerElapsed(NSTimer obj)
     {
-        if (_isTouchOccurred)
+        UpdateRippleEffect();
+        ClampAffectedArea();
+        if (!_isTouchOccurred)
         {
             ResetAffectedArea();
-            _isTouchOccurred = false;
         }
-        UpdateRippleEffect();
+        _isTouchOccurred = false;
         BeginInvokeOnMainThread(() => _canvasView.SetNeedsDisplay());
     }
 

--- a/performance_compare.py
+++ b/performance_compare.py
@@ -1,0 +1,50 @@
+import random, time
+
+size = 325
+rippleMap = [[random.random() for _ in range(size)] for _ in range(size)]
+lastRippleMap = [row[:] for row in rippleMap]
+
+
+def update_full(ripple, last):
+    size = len(ripple)
+    for x in range(1, size - 1):
+        for y in range(1, size - 1):
+            new_height = (
+                ripple[x - 1][y] + ripple[x + 1][y] + ripple[x][y - 1] + ripple[x][y + 1]
+            ) / 2.0 - last[x][y]
+            last[x][y] = new_height * 0.95
+    for x in range(size):
+        ripple[x], last[x] = last[x], ripple[x]
+
+
+def update_partial(ripple, last, startx, endx, starty, endy):
+    size = len(ripple)
+    startx = max(1, startx)
+    endx = min(size - 1, endx)
+    starty = max(1, starty)
+    endy = min(size - 1, endy)
+    for x in range(startx, endx):
+        for y in range(starty, endy):
+            new_height = (
+                ripple[x - 1][y] + ripple[x + 1][y] + ripple[x][y - 1] + ripple[x][y + 1]
+            ) / 2.0 - last[x][y]
+            last[x][y] = new_height * 0.95
+    for x in range(size):
+        ripple[x], last[x] = last[x], ripple[x]
+
+runs = 20
+start = time.perf_counter()
+for _ in range(runs):
+    update_full(rippleMap, lastRippleMap)
+end = time.perf_counter()
+full_time = end - start
+
+rippleMap = [[random.random() for _ in range(size)] for _ in range(size)]
+lastRippleMap = [row[:] for row in rippleMap]
+start = time.perf_counter()
+for _ in range(runs):
+    update_partial(rippleMap, lastRippleMap, 100, 150, 100, 150)
+end = time.perf_counter()
+partial_time = end - start
+
+print(f"full:{full_time:.4f} partial:{partial_time:.4f}")


### PR DESCRIPTION
## Summary
- use affected area bounds to update only changed portions of the map
- clamp affected area indices and reset when no touch occurred
- add a small Python script to compare full vs partial update performance

## Testing
- `python3 performance_compare.py`

------
https://chatgpt.com/codex/tasks/task_e_68529d0079f08324a51284d2d5657a5d