### PR TITLE
Add Swift version usable in Xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # WaterEffect
 
-WaterEffect is a simple iOS sample that demonstrates a dynamic water ripple effect. It is written in C# using Xamarin.iOS. The sample includes an `EnhancedRippleViewController` that renders ripples with SkiaSharp and an `OpenGLWaterEffectViewController` that renders a basic effect with OpenGL.
+WaterEffect is a simple iOS sample that demonstrates a dynamic water ripple effect. Originally written in C# using Xamarin.iOS, the repository now also contains a Swift implementation that can be opened directly in Xcode.
 
 ## Prerequisites
 
-- macOS with [Xamarin.iOS](https://learn.microsoft.com/xamarin/ios/) installed. The easiest way to get started is using **Visual Studio for Mac** or **Visual Studio** on Windows paired with a Mac build host.
+- Xcode 13 or newer.
 - An iOS device or simulator to run the application.
 
-## Building and Running
+## Building and Running (Swift Version)
 
-1. Clone this repository.
-2. Open `WaterEffect.sln` in Visual Studio.
-3. Restore NuGet packages if prompted.
-4. Build the `WaterEffect` project.
-5. Deploy to an iOS simulator or a connected device.
+1. Navigate to the `WaterEffectSwift` folder.
+2. Run `swift package generate-xcodeproj` to create the Xcode project files.
+3. Open the generated `WaterEffectSwift.xcodeproj` in Xcode.
+4. Build and run the app on a simulator or device.
 
-Running the application will display a view where tapping or dragging generates water ripples.
+The Swift version replicates the ripple effect using `UIKit` without external dependencies.
 
-## Splashing Water
+## Building and Running (Original Xamarin Version)
 
-The enhanced ripple controller now tracks velocity for each point on the water surface.
-Touches inject momentum into the velocity maps so quick taps create splash-like effects.
-A small particle sprite (`Resources/Particles.png`) is drawn whenever the velocity is
-high enough, giving visual feedback of splashing water.
+1. Open `WaterEffect.sln` in Visual Studio.
+2. Restore NuGet packages if prompted.
+3. Build the `WaterEffect` project.
+4. Deploy to an iOS simulator or a connected device.
 
+Running either version will display a view where tapping or dragging generates water ripples.

--- a/WaterEffectSwift/Package.swift
+++ b/WaterEffectSwift/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.5
+import PackageDescription
+
+let package = Package(
+    name: "WaterEffectSwift",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        .executable(name: "WaterEffectSwift", targets: ["WaterEffectSwift"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "WaterEffectSwift"
+        )
+    ]
+)

--- a/WaterEffectSwift/Sources/WaterEffectSwift/AppDelegate.swift
+++ b/WaterEffectSwift/Sources/WaterEffectSwift/AppDelegate.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        return true
+    }
+}

--- a/WaterEffectSwift/Sources/WaterEffectSwift/RippleView.swift
+++ b/WaterEffectSwift/Sources/WaterEffectSwift/RippleView.swift
@@ -1,0 +1,156 @@
+import UIKit
+
+class RippleView: UIView {
+    private let mapSize: Int = 128
+    private let initialPressure: Float = 0.7
+    private let damping: Float = 0.95
+
+    private var rippleMap: [[Float]]
+    private var lastRippleMap: [[Float]]
+    private var velocities: VelocityField
+    private var displayLink: CADisplayLink?
+    private var lastTouchPoints: [UITouch: CGPoint] = [:]
+    private var isTouchOccurred = false
+
+    override init(frame: CGRect) {
+        self.rippleMap = Array(repeating: Array(repeating: 0, count: mapSize), count: mapSize)
+        self.lastRippleMap = self.rippleMap
+        self.velocities = VelocityField(size: mapSize)
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        self.rippleMap = Array(repeating: Array(repeating: 0, count: mapSize), count: mapSize)
+        self.lastRippleMap = self.rippleMap
+        self.velocities = VelocityField(size: mapSize)
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        isMultipleTouchEnabled = true
+        displayLink = CADisplayLink(target: self, selector: #selector(step))
+        displayLink?.add(to: .main, forMode: .common)
+    }
+
+    @objc private func step() {
+        updateRippleEffect()
+        setNeedsDisplay()
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        handleTouches(touches, touchBegan: true)
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesMoved(touches, with: event)
+        handleTouches(touches, touchBegan: false)
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        removeTouchPoints(touches)
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesCancelled(touches, with: event)
+        removeTouchPoints(touches)
+    }
+
+    private func handleTouches(_ touches: Set<UITouch>, touchBegan: Bool) {
+        for touch in touches {
+            let location = touch.location(in: self)
+            var pressure: Float = 1.0
+            if touch.maximumPossibleForce > 0 {
+                pressure = Float(touch.force / touch.maximumPossibleForce)
+            }
+            pressure = min(max(pressure, 0.1), 1.0)
+            if touchBegan {
+                applyInitialRipple(at: location, pressure: pressure)
+            } else if let last = lastTouchPoints[touch] {
+                interpolateRipples(from: last, to: location, pressure: pressure)
+            }
+            lastTouchPoints[touch] = location
+        }
+    }
+
+    private func removeTouchPoints(_ touches: Set<UITouch>) {
+        for touch in touches {
+            lastTouchPoints.removeValue(forKey: touch)
+        }
+    }
+
+    private func applyInitialRipple(at point: CGPoint, pressure: Float) {
+        let (x, y) = mapCoordinates(point)
+        applyRipple(x: x, y: y, pressure: pressure, damping: damping)
+        isTouchOccurred = true
+    }
+
+    private func interpolateRipples(from start: CGPoint, to end: CGPoint, pressure: Float) {
+        let dynamicDamping = damping
+        let steps = Int(max(abs(end.x - start.x), abs(end.y - start.y)))
+        for i in 0...steps {
+            let t = CGFloat(i) / CGFloat(max(steps, 1))
+            let point = CGPoint(x: start.x + t*(end.x - start.x), y: start.y + t*(end.y - start.y))
+            let (mx, my) = mapCoordinates(point)
+            applyRipple(x: mx, y: my, pressure: pressure, damping: dynamicDamping)
+        }
+    }
+
+    private func mapCoordinates(_ point: CGPoint) -> (Int, Int) {
+        let mapX = Int(point.x * CGFloat(mapSize) / bounds.width)
+        let mapY = Int(point.y * CGFloat(mapSize) / bounds.height)
+        return (mapX, mapY)
+    }
+
+    private func applyRipple(x: Int, y: Int, pressure: Float, damping: Float) {
+        let impactRadius = Int(ceil(3 * pressure))
+        for dx in -impactRadius...impactRadius {
+            for dy in -impactRadius...impactRadius {
+                let nx = x + dx
+                let ny = y + dy
+                if nx >= 1 && nx < mapSize - 1 && ny >= 1 && ny < mapSize - 1 {
+                    rippleMap[nx][ny] += initialPressure * pressure / Float(abs(dx)+abs(dy)+1) * damping
+                    velocities.x[nx][ny] += Float(dx) * pressure
+                    velocities.y[nx][ny] += Float(dy) * pressure
+                }
+            }
+        }
+    }
+
+    private func updateRippleEffect() {
+        let size = mapSize
+        for x in 1..<size-1 {
+            for y in 1..<size-1 {
+                let gradX = rippleMap[x+1][y] - rippleMap[x-1][y]
+                let gradY = rippleMap[x][y+1] - rippleMap[x][y-1]
+                velocities.x[x][y] += -gradX * 0.03
+                velocities.y[x][y] += -gradY * 0.03
+                velocities.x[x][y] *= damping
+                velocities.y[x][y] *= damping
+                let newHeight = rippleMap[x][y] + (velocities.x[x][y] + velocities.y[x][y]) * 0.5
+                lastRippleMap[x][y] = newHeight
+            }
+        }
+        swap(&rippleMap, &lastRippleMap)
+    }
+
+    override func draw(_ rect: CGRect) {
+        guard let ctx = UIGraphicsGetCurrentContext() else { return }
+        ctx.setFillColor(UIColor.black.cgColor)
+        ctx.fill(rect)
+        let rectWidth = rect.width / CGFloat(mapSize)
+        let rectHeight = rect.height / CGFloat(mapSize)
+        for x in 0..<mapSize {
+            for y in 0..<mapSize {
+                let value = rippleMap[x][y]
+                let alpha = max(0, min(1, value))
+                ctx.setFillColor(UIColor.blue.withAlphaComponent(CGFloat(alpha)).cgColor)
+                let r = CGRect(x: CGFloat(x)*rectWidth, y: CGFloat(y)*rectHeight, width: rectWidth, height: rectHeight)
+                ctx.fill(r)
+            }
+        }
+    }
+}

--- a/WaterEffectSwift/Sources/WaterEffectSwift/RippleViewController.swift
+++ b/WaterEffectSwift/Sources/WaterEffectSwift/RippleViewController.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+class RippleViewController: UIViewController {
+    override func loadView() {
+        self.view = RippleView(frame: UIScreen.main.bounds)
+    }
+
+    override var prefersStatusBarHidden: Bool { true }
+}

--- a/WaterEffectSwift/Sources/WaterEffectSwift/SceneDelegate.swift
+++ b/WaterEffectSwift/Sources/WaterEffectSwift/SceneDelegate.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene,
+               willConnectTo session: UISceneSession,
+               options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = RippleViewController()
+        self.window = window
+        window.makeKeyAndVisible()
+    }
+}

--- a/WaterEffectSwift/Sources/WaterEffectSwift/VelocityField.swift
+++ b/WaterEffectSwift/Sources/WaterEffectSwift/VelocityField.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+class VelocityField {
+    var x: [[Float]]
+    var y: [[Float]]
+    let size: Int
+
+    init(size: Int) {
+        self.size = size
+        self.x = Array(repeating: Array(repeating: 0.0, count: size), count: size)
+        self.y = Array(repeating: Array(repeating: 0.0, count: size), count: size)
+    }
+
+    func clear() {
+        for i in 0..<size {
+            for j in 0..<size {
+                x[i][j] = 0
+                y[i][j] = 0
+            }
+        }
+    }
+}

--- a/WaterEffectSwift/Sources/WaterEffectSwift/main.swift
+++ b/WaterEffectSwift/Sources/WaterEffectSwift/main.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+UIApplicationMain(
+    CommandLine.argc,
+    CommandLine.unsafeArgv,
+    nil,
+    NSStringFromClass(AppDelegate.self)
+)


### PR DESCRIPTION
## Summary
- create `WaterEffectSwift` Swift package for Xcode editing
- port ripple effect to Swift (`RippleView` etc.)
- update README with new build instructions
- remove unused particle image from Swift resources

## Testing
- `dotnet build WaterEffect.sln` *(fails: `dotnet` not found)*
- `swift build` *(fails: no such module `UIKit`)*


------
https://chatgpt.com/codex/tasks/task_e_685a74d6581883249b045136c1c3f350